### PR TITLE
fix: update permissions and correct typo in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: tests
 
 permissions:
-  packages: write
+  contents: read
 
 on:
   workflow_dispatch:
@@ -14,6 +14,8 @@ on:
 jobs:
   test-go:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -48,7 +50,8 @@ jobs:
   style-go:
     name: style
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -71,6 +74,8 @@ jobs:
     name: Build and Test Container
     needs: [test-go, style-go]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -99,8 +104,11 @@ jobs:
           wget -q -O - 127.0.0.1:8282/version | grep -i version
 
   containerization-build-push:
-    name: Build and push multi-architecture containter
+    name: Build and push multi-architecture container
     needs: [containerization-test]
+    permissions:
+      contents: read
+      packages: write
     if: |
       github.event_name == 'push' && 
       startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
- Changed permissions from 'packages: write' to 'contents: read' for better security.
- Added 'contents: read' permissions to individual jobs for consistency.
- Corrected typo in job name from 'containter' to 'container'.